### PR TITLE
Add functional areas for IP wards

### DIFF
--- a/notebooks/produce_functional_area_aggs.ipynb
+++ b/notebooks/produce_functional_area_aggs.ipynb
@@ -281,7 +281,7 @@
     }
    },
    "source": [
-    "## IP"
+    "## IP: Load data"
    ]
   },
   {
@@ -408,7 +408,8 @@
     "\n",
     "upload_data(env_vars, metadata, final_aae_df, \"aae\")\n",
     "upload_data(env_vars, metadata, final_op_df, \"op\")\n",
-    "upload_data(env_vars, metadata, final_ip_daycase_df, \"ip_daycase\")"
+    "upload_data(env_vars, metadata, final_ip_daycase_df, \"ip_daycase\")\n",
+    "upload_data(env_vars, metadata, final_ip_wards_df, \"ip_wards\")"
    ]
   },
   {

--- a/notebooks/produce_functional_area_aggs.ipynb
+++ b/notebooks/produce_functional_area_aggs.ipynb
@@ -107,12 +107,18 @@
     "from nhp.capacity.functional_areas.ip_daycase import (\n",
     "    process_ip_daycase,\n",
     "    qa_ip_daycase_results,\n",
-    "    get_tretspef_lookup,\n",
-    "    add_tretspef_type,\n",
+    ")\n",
+    "from nhp.capacity.functional_areas.ip_wards import (\n",
+    "    process_ip_wards,\n",
+    "    qa_ip_wards_results,\n",
     ")\n",
     "from nhp.capacity.functional_areas.saving_helpers import (\n",
     "    upload_data,\n",
     "    add_metadata_to_ats,\n",
+    ")\n",
+    "from nhp.capacity.functional_areas.processing_helpers import (\n",
+    "    get_tretspef_lookup,\n",
+    "    add_tretspef_type,\n",
     ")\n",
     "from datetime import datetime\n",
     "import uuid\n",
@@ -275,6 +281,29 @@
     }
    },
    "source": [
+    "## IP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "sites_ip = dbutils.widgets.get(\"sites_ip\").split(\",\")\n",
+    "ip_original = load_model_data(demand_model_version, \"ip\", fyear, provider, sites_ip)\n",
+    "ip_model_results = spark.read.parquet(db_path_to_full_model_results + \"ip\")\n",
+    "tretspef_lookup_df = get_tretspef_lookup(\n",
+    "    excel_path=\"/Volumes/nhp/reference/files/daycase_tretspef_mapping.xlsx\"\n",
+    ")\n",
+    "ip_original_mapped = add_tretspef_type(ip_original, tretspef_lookup_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## IP Daycase"
    ]
   },
@@ -296,21 +325,33 @@
    },
    "outputs": [],
    "source": [
-    "# Load data\n",
-    "sites_ip = dbutils.widgets.get(\"sites_ip\").split(\",\")\n",
-    "ip_original = load_model_data(demand_model_version, \"ip\", fyear, provider, sites_ip)\n",
-    "ip_model_results = spark.read.parquet(db_path_to_full_model_results + \"ip\")\n",
-    "tretspef_lookup_df = get_tretspef_lookup(\n",
-    "    excel_path=\"/Volumes/nhp/reference/files/daycase_tretspef_mapping.xlsx\"\n",
-    ")\n",
-    "ip_original_mapped = add_tretspef_type(ip_original, tretspef_lookup_df)\n",
-    "\n",
     "# Process data\n",
     "final_ip_daycase_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",
     "\n",
     "# QA processed data\n",
     "default_ip_results = load_default_results(db_path_to_full_model_results, \"ip\", sites_ip)\n",
     "qa_ip_daycase_results(default_ip_results, final_ip_daycase_df, sites_ip)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## IP Wards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Process data\n",
+    "final_ip_wards_df = process_ip_wards(ip_original_mapped, ip_model_results)\n",
+    "\n",
+    "# QA processed data\n",
+    "default_ip_results = load_default_results(db_path_to_full_model_results, \"ip\", sites_ip)\n",
+    "qa_ip_wards_results(default_ip_results, final_ip_wards_df, sites_ip)"
    ]
   },
   {

--- a/src/nhp/capacity/functional_areas/ip_daycase.py
+++ b/src/nhp/capacity/functional_areas/ip_daycase.py
@@ -1,50 +1,12 @@
-import pyspark.sql.functions as F
-import pandas as pd
-from pyspark.sql import DataFrame
-from nhp.capacity.functional_areas.processing_helpers import add_missing_groupings
-from databricks.connect import DatabricksSession
 from typing import List
 
+import pyspark.sql.functions as F
+from databricks.connect import DatabricksSession
+from pyspark.sql import DataFrame
+
+from nhp.capacity.functional_areas.processing_helpers import add_missing_groupings
+
 spark = DatabricksSession.builder.getOrCreate()
-
-
-def get_tretspef_lookup(
-    excel_path: str,
-) -> DataFrame:
-    """Load tretspef lookup file from given location. Currently using custom edit of
-    https://digital.nhs.uk/binaries/content/assets/website-assets/isce/dcb0028/0028452019codelistspecificationv1.2.xlsx
-
-    Args:
-        excel_path (str): Path to Excel file
-
-    Returns:
-        DataFrame: DataFrame with two columns, tretspef (treatment function code) and treatment specialty type (medical/surgical)
-    """
-    tretspef_lookup = pd.read_excel(excel_path, engine="openpyxl")
-    tretspef_lookup["tretspef"] = tretspef_lookup["tretspef"].astype(int)
-    tretspef_lookup_df = spark.createDataFrame(
-        tretspef_lookup.rename(columns={"NHP categorisation": "tretspef_type"})
-    )
-    return tretspef_lookup_df
-
-
-def add_tretspef_type(
-    ip_original: DataFrame, tretspef_lookup_df: DataFrame
-) -> DataFrame:
-    """Adds tretspef_type column to inpatients data to help with mapping daycase activity to medical/surgical
-
-    Args:
-        ip_original (DataFrame): Inpatients model data
-        tretspef_lookup_df (DataFrame): DataFrame mapping treatment specialty code to treatment specialty type (medical/surgical)
-
-    Returns:
-        DataFrame: Inpatients model data with additional tretspef_type column
-    """
-    return ip_original.join(
-        tretspef_lookup_df,
-        on=ip_original["tretspef"] == tretspef_lookup_df["tretspef"],
-        how="left",
-    ).drop(tretspef_lookup_df["tretspef"])
 
 
 def create_ip_daycase_groupings(ip_data: DataFrame) -> DataFrame:

--- a/src/nhp/capacity/functional_areas/ip_wards.py
+++ b/src/nhp/capacity/functional_areas/ip_wards.py
@@ -1,0 +1,193 @@
+from typing import List
+
+import pyspark.sql.functions as F
+from databricks.connect import DatabricksSession
+from pyspark.sql import DataFrame
+
+from nhp.capacity.functional_areas.processing_helpers import add_missing_groupings
+
+spark = DatabricksSession.builder.getOrCreate()
+
+
+def create_ip_ward_groupings(ip_data: DataFrame) -> DataFrame:
+    """Adds "grouping" column to the IP data with the functional areas for IP wards
+
+    Args:
+        ip_data (DataFrame): IP data
+
+    Returns:
+        DataFrame: IP data, aggregated by ward functional areas
+    """
+    filtered = ip_data.filter(
+        F.col("pod").isin(["ip_non-elective_admission", "ip_elective_admission"])
+    )
+    df_with_grouping = filtered.withColumn(
+        "grouping",
+        F.concat_ws(
+            "_",
+            # age group
+            F.when(F.col("admiage") > 17, "adult").otherwise("paediatric"),
+            # admission type
+            F.when(F.col("pod") == "ip_non-elective_admission", "nonelective").when(
+                F.col("pod") == "ip_elective_admission", "elective"
+            ),
+            # specialty
+            F.when(F.col("tretspef_type") == "Surgical", "surgical").when(
+                F.col("tretspef_type") == "Medical/Other", "medical"
+            ),
+            # optional 0los suffix
+            F.when(F.col("speldur") == 0, "0los"),
+        ),
+    )
+    df_grouped = df_with_grouping.groupBy("model_run", "grouping").agg(
+        F.sum("speldur").alias("beddays"), F.count("*").alias("spells")
+    )
+    df_final = (
+        df_grouped.select(
+            "model_run",
+            F.concat(F.col("grouping"), F.lit("_beddays")).alias("grouping_beddays"),
+            F.col("beddays"),
+            F.concat(F.col("grouping"), F.lit("_spells")).alias("grouping_spells"),
+            F.col("spells"),
+        )
+        .select(
+            "model_run",
+            F.explode(
+                F.array(
+                    F.struct(
+                        F.col("grouping_beddays").alias("grouping"),
+                        F.col("beddays").alias("total"),
+                    ),
+                    F.struct(
+                        F.col("grouping_spells").alias("grouping"),
+                        F.col("spells").alias("total"),
+                    ),
+                )
+            ).alias("kv"),
+        )
+        .select("model_run", F.col("kv.grouping"), F.col("kv.total"))
+    )
+    return df_final
+
+
+def process_ip_wards(
+    ip_original_mapped: DataFrame, ip_model_results: DataFrame
+) -> DataFrame:
+    """Processes and aggregates the IP baseline and model results to produce functional area outputs for IP daycase,
+    aggregated by model run and grouping.
+
+    Args:
+        ip_original_mapped (DataFrame): Baseline IP data
+        ip_model_results (DataFrame): IP full model results
+
+    Returns:
+        DataFrame: IP data for each of the model runs aggregated into functional areas for IP wards
+    """
+    baseline_grouped = create_ip_ward_groupings(ip_original_mapped)
+    groupings_per_run = create_ip_ward_groupings(
+        ip_original_mapped.drop("speldur", "classpat", "model_run")
+        .join(ip_model_results, on="rn", how="left")
+        .withColumn(
+            "pod",
+            F.when(F.col("classpat") == "-2", "ip_elective_daycase")
+            .when(F.col("classpat") == "-1", "op_procedure")
+            .when(F.col("classpat") == "-3", "aae_type-05")
+            .otherwise(F.col("pod")),
+        )
+    )
+    final_groupings_per_run_with_baseline = groupings_per_run.unionByName(
+        baseline_grouped
+    )
+    # Add missing groupings - we need all groupings to be present in all model runs even if value is 0
+    required_ip_groupings = [
+        "paediatric_nonelective_surgical_beddays",
+        "paediatric_nonelective_surgical_spells",
+        "adult_nonelective_medical_0los_beddays",
+        "adult_nonelective_medical_0los_spells",
+        "adult_nonelective_medical_beddays",
+        "adult_nonelective_medical_spells",
+        "adult_elective_surgical_0los_beddays",
+        "adult_elective_surgical_0los_spells",
+        "paediatric_nonelective_medical_0los_beddays",
+        "paediatric_nonelective_medical_0los_spells",
+        "adult_elective_medical_0los_beddays",
+        "adult_elective_medical_0los_spells",
+        "paediatric_elective_medical_0los_beddays",
+        "paediatric_elective_medical_0los_spells",
+        "paediatric_nonelective_surgical_0los_beddays",
+        "paediatric_nonelective_surgical_0los_spells",
+        "paediatric_elective_surgical_0los_beddays",
+        "paediatric_elective_surgical_0los_spells",
+        "adult_nonelective_surgical_0los_beddays",
+        "adult_nonelective_surgical_0los_spells",
+        "paediatric_elective_surgical_beddays",
+        "paediatric_elective_surgical_spells",
+        "adult_nonelective_surgical_beddays",
+        "adult_nonelective_surgical_spells",
+        "paediatric_nonelective_medical_beddays",
+        "paediatric_nonelective_medical_spells",
+        "paediatric_elective_medical_beddays",
+        "paediatric_elective_medical_spells",
+        "adult_elective_surgical_beddays",
+        "adult_elective_surgical_spells",
+        "adult_elective_medical_beddays",
+        "adult_elective_medical_spells",
+    ]
+    final_df = add_missing_groupings(
+        final_groupings_per_run_with_baseline, required_ip_groupings
+    )
+    return final_df
+
+
+def qa_ip_wards_results(
+    default_results: DataFrame, final_ip_wards_df: DataFrame, sites: List[str]
+):
+    """Quality Assurance step: checks that values in a given column produce the same mean in new functional area
+    aggregations as with default model results.
+
+    Args:
+        default_results (DataFrame): Default model results
+        final_ip_wards_df (DataFrame): DataFrame of functional area pipeline outputs
+        sites (List[str]):
+    """
+    if "ALL" not in sites:
+        default_results = default_results.where((F.col("sitetret").isin(sites)))
+    default_results = default_results.filter(
+        F.col("pod").isin(["ip_non-elective_admission", "ip_elective_admission"])
+    )
+    default_results_value = (
+        default_results.groupBy("model_run", "measure")
+        .agg(F.sum("value").alias("value"))
+        .groupby("measure")
+        .agg(F.mean("value").alias("mean"))
+    )
+    default_results_dict = dict(
+        default_results_value.select("measure", "mean").collect()
+    )
+    grouped_value = (
+        final_ip_wards_df.filter(F.col("model_run") != 0)
+        .withColumn(
+            "measure",
+            F.when(F.col("grouping").endswith("beddays"), F.lit("beddays")).when(
+                F.col("grouping").endswith("spells"), F.lit("admissions")
+            ),
+        )
+        .groupBy("model_run", "measure")
+        .agg(F.sum("total").alias("total"))
+        .groupBy("measure")
+        .agg(F.mean("total").alias("mean"))
+    )
+    grouped_dict = dict(grouped_value.select("measure", "mean").collect())
+    try:
+        adjusted_beddays_default = (
+            default_results_dict["beddays"] - default_results_dict["admissions"]
+        )
+        assert float(adjusted_beddays_default) == float(grouped_dict["beddays"])
+        assert float(default_results_dict["admissions"]) == float(
+            grouped_dict["admissions"]
+        )
+    except AssertionError:
+        print(
+            "Aggregated results are not aligned with default model results. Check IP wards calculations"
+        )
+        raise

--- a/src/nhp/capacity/functional_areas/ip_wards.py
+++ b/src/nhp/capacity/functional_areas/ip_wards.py
@@ -89,10 +89,9 @@ def process_ip_wards(
         .join(ip_model_results, on="rn", how="left")
         .withColumn(
             "pod",
-            F.when(F.col("classpat") == "-2", "ip_elective_daycase")
-            .when(F.col("classpat") == "-1", "op_procedure")
-            .when(F.col("classpat") == "-3", "aae_type-05")
-            .otherwise(F.col("pod")),
+            F.when(F.col("classpat") == "2", "ip_elective_daycase").otherwise(
+                F.col("pod")
+            ),
         )
     )
     final_groupings_per_run_with_baseline = groupings_per_run.unionByName(

--- a/src/nhp/capacity/functional_areas/processing_helpers.py
+++ b/src/nhp/capacity/functional_areas/processing_helpers.py
@@ -1,7 +1,9 @@
-from databricks.connect import DatabricksSession
-import pyspark.sql.functions as F
-from pyspark.sql import DataFrame
 from typing import List
+
+import pandas as pd
+import pyspark.sql.functions as F
+from databricks.connect import DatabricksSession
+from pyspark.sql import DataFrame
 
 spark = DatabricksSession.builder.getOrCreate()
 
@@ -32,3 +34,42 @@ def add_missing_groupings(
     )
     final_df = non_required.unionByName(completed_required)
     return final_df
+
+
+def get_tretspef_lookup(
+    excel_path: str,
+) -> DataFrame:
+    """Load tretspef lookup file from given location. Currently using custom edit of
+    https://digital.nhs.uk/binaries/content/assets/website-assets/isce/dcb0028/0028452019codelistspecificationv1.2.xlsx
+
+    Args:
+        excel_path (str): Path to Excel file
+
+    Returns:
+        DataFrame: DataFrame with two columns, tretspef (treatment function code) and treatment specialty type (medical/surgical)
+    """
+    tretspef_lookup = pd.read_excel(excel_path, engine="openpyxl")
+    tretspef_lookup["tretspef"] = tretspef_lookup["tretspef"].astype(int)
+    tretspef_lookup_df = spark.createDataFrame(
+        tretspef_lookup.rename(columns={"NHP categorisation": "tretspef_type"})
+    )
+    return tretspef_lookup_df
+
+
+def add_tretspef_type(
+    ip_original: DataFrame, tretspef_lookup_df: DataFrame
+) -> DataFrame:
+    """Adds tretspef_type column to inpatients data to help with mapping daycase activity to medical/surgical
+
+    Args:
+        ip_original (DataFrame): Inpatients model data
+        tretspef_lookup_df (DataFrame): DataFrame mapping treatment specialty code to treatment specialty type (medical/surgical)
+
+    Returns:
+        DataFrame: Inpatients model data with additional tretspef_type column
+    """
+    return ip_original.join(
+        tretspef_lookup_df,
+        on=ip_original["tretspef"] == tretspef_lookup_df["tretspef"],
+        how="left",
+    ).drop(tretspef_lookup_df["tretspef"])


### PR DESCRIPTION
Closes #3. Creates new functional area aggregations listed below, in the file `ip_wards.parquet`

paediatric_nonelective_surgical_beddays
paediatric_nonelective_surgical_spells
adult_nonelective_medical_0los_beddays
adult_nonelective_medical_0los_spells
adult_nonelective_medical_beddays
adult_nonelective_medical_spells
adult_elective_surgical_0los_beddays
adult_elective_surgical_0los_spells
paediatric_nonelective_medical_0los_beddays
paediatric_nonelective_medical_0los_spells
adult_elective_medical_0los_beddays
adult_elective_medical_0los_spells
paediatric_elective_medical_0los_beddays
paediatric_elective_medical_0los_spells
paediatric_nonelective_surgical_0los_beddays
paediatric_nonelective_surgical_0los_spells
paediatric_elective_surgical_0los_beddays
paediatric_elective_surgical_0los_spells
adult_nonelective_surgical_0los_beddays
adult_nonelective_surgical_0los_spells
paediatric_elective_surgical_beddays
paediatric_elective_surgical_spells
adult_nonelective_surgical_beddays
adult_nonelective_surgical_spells
paediatric_nonelective_medical_beddays
paediatric_nonelective_medical_spells
paediatric_elective_medical_beddays
paediatric_elective_medical_spells
adult_elective_surgical_beddays
adult_elective_surgical_spells
adult_elective_medical_beddays
adult_elective_medical_spells
