### PR TITLE
Add maternity functional area classifications

### DIFF
--- a/notebooks/produce_functional_area_aggs.ipynb
+++ b/notebooks/produce_functional_area_aggs.ipynb
@@ -340,11 +340,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Process data\n",
-    "final_ip_daycase_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",
+    "final_ip_maternity_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",
     "\n",
     "# QA not possible due to groupings not aligning with NHP model outputs"
    ]
@@ -403,7 +405,8 @@
     "\n",
     "upload_data(env_vars, metadata, final_aae_df, \"aae\")\n",
     "upload_data(env_vars, metadata, final_op_df, \"op\")\n",
-    "upload_data(env_vars, metadata, final_ip_daycase_df, \"ip_daycase\")"
+    "upload_data(env_vars, metadata, final_ip_daycase_df, \"ip_daycase\")\n",
+    "upload_data(env_vars, metadata, final_ip_maternity_df, \"ip_maternity\")"
    ]
   },
   {

--- a/notebooks/produce_functional_area_aggs.ipynb
+++ b/notebooks/produce_functional_area_aggs.ipynb
@@ -346,7 +346,7 @@
    "outputs": [],
    "source": [
     "# Process data\n",
-    "final_ip_maternity_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",
+    "final_ip_maternity_df = process_ip_maternity(ip_original_mapped, ip_model_results)\n",
     "\n",
     "# QA not possible due to groupings not aligning with NHP model outputs"
    ]

--- a/notebooks/produce_functional_area_aggs.ipynb
+++ b/notebooks/produce_functional_area_aggs.ipynb
@@ -108,6 +108,10 @@
     "    process_ip_daycase\n",
     ")\n",
     "\n",
+    "from nhp.capacity.functional_areas.ip_maternity import (\n",
+    "    process_ip_maternity\n",
+    ")\n",
+    "\n",
     "from nhp.capacity.functional_areas.saving_helpers import (\n",
     "    upload_data,\n",
     "    add_metadata_to_ats,\n",
@@ -321,6 +325,23 @@
     }
    },
    "outputs": [],
+   "source": [
+    "# Process data\n",
+    "final_ip_daycase_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",
+    "\n",
+    "# QA not possible due to groupings not aligning with NHP model outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## IP Maternity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Process data\n",
     "final_ip_daycase_df = process_ip_daycase(ip_original_mapped, ip_model_results)\n",

--- a/src/nhp/capacity/functional_areas/classifications.py
+++ b/src/nhp/capacity/functional_areas/classifications.py
@@ -48,6 +48,8 @@ ENDOSCOPY_PROCEDURE_CODES = [
     "E51",
 ]
 
+ASSISTED_BIRTHS_CODES = ["R19", "R20", "R21", "R22", "R23"]
+
 
 def class_age_adult() -> Column:
     return F.col("age") >= 18
@@ -112,6 +114,10 @@ def class_zero_los() -> Column:
     return F.col("speldur") == 0
 
 
+def class_non_zero_los() -> Column:
+    return F.col("speldur") > 0
+
+
 def class_regular_day_night() -> Column:
     return F.col("classpat").isin("3", "4")
 
@@ -134,3 +140,31 @@ def class_medical() -> Column:
 
 def class_surgical() -> Column:
     return F.col("tretspef_type") == "Surgical"
+
+
+def class_maternity() -> Column:
+    return F.col("group") == "maternity"
+
+
+def class_birth_event() -> Column:
+    return F.col("maternity_delivery_in_spell")
+
+
+def class_birth_normal() -> Column:
+    return F.col("primary_procedure").substr(1, 3) == "R24"
+
+
+def class_birth_assisted() -> Column:
+    return F.col("primary_procedure").substr(1, 3).isin(ASSISTED_BIRTHS_CODES)
+
+
+def class_birth_nonelective_c_section() -> Column:
+    return F.col("primary_procedure").substr(1, 3) == "R18"
+
+
+def class_no_birth_flag() -> Column:
+    return ~F.col("maternity_delivery_in_spell")
+
+
+def class_birth_elective_csection() -> Column:
+    return F.col("primary_procedure").substr(1, 3) == "R17"

--- a/src/nhp/capacity/functional_areas/classifications.py
+++ b/src/nhp/capacity/functional_areas/classifications.py
@@ -162,7 +162,7 @@ def class_birth_nonelective_c_section() -> Column:
     return F.col("primary_procedure").substr(1, 3) == "R18"
 
 
-def class_no_birth_flag() -> Column:
+def class_no_birth_event() -> Column:
     return ~F.col("maternity_delivery_in_spell")
 
 

--- a/src/nhp/capacity/functional_areas/ip_maternity.py
+++ b/src/nhp/capacity/functional_areas/ip_maternity.py
@@ -18,24 +18,80 @@ from nhp.capacity.functional_areas.processing_helpers import add_missing_groupin
 spark = DatabricksSession.builder.getOrCreate()
 
 
-def is_normal_delivery():
-    return class_maternity() & class_birth_event() & class_birth_normal()
+def is_normal_delivery_nonzerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_normal()
+        & class_non_zero_los()
+    )
 
 
-def is_assisted_delivery():
-    return class_maternity() & class_birth_event() & class_birth_assisted()
+def is_normal_delivery_zerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_normal()
+        & class_zero_los()
+    )
+
+
+def is_assisted_delivery_nonzerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_assisted()
+        & class_non_zero_los()
+    )
+
+
+def is_assisted_delivery_zerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_assisted()
+        & class_zero_los()
+    )
 
 
 def is_maternity_assessment():
     return class_maternity() & class_zero_los() & class_no_birth_event()
 
 
-def is_nonelective_csection():
-    return class_maternity() & class_birth_event() & class_birth_nonelective_c_section()
+def is_nonelective_csection_nonzerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_nonelective_c_section()
+        & class_non_zero_los()
+    )
 
 
-def is_elective_csection():
-    return class_maternity() & class_birth_event() & class_birth_elective_csection()
+def is_nonelective_csection_zerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_nonelective_c_section()
+        & class_zero_los()
+    )
+
+
+def is_elective_csection_nonzerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_elective_csection()
+        & class_non_zero_los()
+    )
+
+
+def is_elective_csection_zerolos():
+    return (
+        class_maternity()
+        & class_birth_event()
+        & class_birth_elective_csection()
+        & class_zero_los()
+    )
 
 
 def is_overnight_no_birth_event():
@@ -54,15 +110,33 @@ def create_ip_maternity_groupings(ip_data: DataFrame) -> DataFrame:
     df = (
         ip_data.withColumn(
             "grouping",
-            F.when(is_normal_delivery(), "maternity_normal_delivery")
-            .when(is_assisted_delivery(), "maternity_assisted_delivery")
+            F.when(is_normal_delivery_zerolos(), "maternity_normal_delivery_zerolos")
+            .when(
+                is_normal_delivery_nonzerolos(), "maternity_normal_delivery_nonzerolos"
+            )
+            .when(is_assisted_delivery_zerolos(), "maternity_assisted_delivery_zerolos")
+            .when(
+                is_assisted_delivery_nonzerolos(),
+                "maternity_assisted_delivery_nonzerolos",
+            )
             .when(is_maternity_assessment(), "maternity_assessment")
-            .when(is_nonelective_csection(), "maternity_nonelective_csection")
-            .when(is_elective_csection(), "maternity_elective_csection")
+            .when(
+                is_nonelective_csection_zerolos(),
+                "maternity_nonelective_csection_zerolos",
+            )
+            .when(
+                is_nonelective_csection_nonzerolos(),
+                "maternity_nonelective_csection_nonzerolos",
+            )
+            .when(is_elective_csection_zerolos(), "maternity_elective_csection_zerolos")
+            .when(
+                is_elective_csection_nonzerolos(),
+                "maternity_elective_csection_nonzerolos",
+            )
             .when(is_overnight_no_birth_event(), "maternity_overnight_no_birth"),
         )
         .groupby("grouping", "model_run")
-        .agg(F.count("rn").alias("total"))
+        .agg(F.count("rn").alias("spells"), F.sum("speldur").alias("beddays"))
     )
     return df
 
@@ -91,11 +165,15 @@ def process_ip_maternity(
     )
     # Add missing groupings - we need all groupings to be present in all model runs even if value is 0
     required_ip_groupings = [
-        "maternity_normal_delivery",
-        "maternity_assisted_delivery",
+        "maternity_normal_delivery_zerolos",
+        "maternity_normal_delivery_nonzerolos",
+        "maternity_assisted_delivery_zerolos",
+        "maternity_assisted_delivery_nonzerolos",
         "maternity_assessment",
-        "maternity_nonelective_csection",
-        "maternity_elective_csection",
+        "maternity_nonelective_csection_zerolos",
+        "maternity_nonelective_csection_nonzerolos",
+        "maternity_elective_csection_zerolos",
+        "maternity_elective_csection_nonzerolos",
         "maternity_overnight_no_birth",
     ]
     final_df = add_missing_groupings(

--- a/src/nhp/capacity/functional_areas/ip_maternity.py
+++ b/src/nhp/capacity/functional_areas/ip_maternity.py
@@ -55,7 +55,7 @@ def create_ip_maternity_groupings(ip_data: DataFrame) -> DataFrame:
         ip_data.withColumn(
             "grouping",
             F.when(is_normal_delivery(), "maternity_normal_delivery")
-            .when(is_assisted_delivery(), "maternity_assissted_delivery")
+            .when(is_assisted_delivery(), "maternity_assisted_delivery")
             .when(is_maternity_assessment(), "maternity_assessment")
             .when(is_nonelective_csection(), "maternity_nonelective_csection")
             .when(is_elective_csection(), "maternity_elective_csection")

--- a/src/nhp/capacity/functional_areas/ip_maternity.py
+++ b/src/nhp/capacity/functional_areas/ip_maternity.py
@@ -43,13 +43,13 @@ def is_overnight_no_birth_event():
 
 
 def create_ip_maternity_groupings(ip_data: DataFrame) -> DataFrame:
-    """Adds "grouping" column to the IP data with the functional areas for IP daycase
+    """Adds "grouping" column to the IP data with the functional areas for IP maternity
 
     Args:
         ip_data (DataFrame): IP data
 
     Returns:
-        DataFrame: IP data, aggregated by daycase functional areas
+        DataFrame: IP data, aggregated by maternity functional areas
     """
     df = (
         ip_data.withColumn(
@@ -67,10 +67,10 @@ def create_ip_maternity_groupings(ip_data: DataFrame) -> DataFrame:
     return df
 
 
-def process_ip_daycase(
+def process_ip_maternity(
     ip_original_mapped: DataFrame, ip_model_results: DataFrame
 ) -> DataFrame:
-    """Processes and aggregates the IP baseline and model results to produce functional area outputs for IP daycase,
+    """Processes and aggregates the IP baseline and model results to produce functional area outputs for IP maternity,
     aggregated by model run and grouping.
 
     Args:
@@ -78,7 +78,7 @@ def process_ip_daycase(
         ip_model_results (DataFrame): IP full model results
 
     Returns:
-        DataFrame: IP data for each of the model runs aggregated into functional areas for daycase
+        DataFrame: IP data for each of the model runs aggregated into functional areas for maternity
     """
     baseline_grouped = create_ip_maternity_groupings(ip_original_mapped)
     groupings_per_run = create_ip_maternity_groupings(

--- a/src/nhp/capacity/functional_areas/ip_maternity.py
+++ b/src/nhp/capacity/functional_areas/ip_maternity.py
@@ -1,0 +1,104 @@
+import pyspark.sql.functions as F
+from databricks.connect import DatabricksSession
+from pyspark.sql import DataFrame
+
+from nhp.capacity.functional_areas.classifications import (
+    class_birth_assisted,
+    class_birth_elective_csection,
+    class_birth_event,
+    class_birth_nonelective_c_section,
+    class_birth_normal,
+    class_maternity,
+    class_no_birth_event,
+    class_non_zero_los,
+    class_zero_los,
+)
+from nhp.capacity.functional_areas.processing_helpers import add_missing_groupings
+
+spark = DatabricksSession.builder.getOrCreate()
+
+
+def is_normal_delivery():
+    return class_maternity() & class_birth_event() & class_birth_normal()
+
+
+def is_assisted_delivery():
+    return class_maternity() & class_birth_event() & class_birth_assisted()
+
+
+def is_maternity_assessment():
+    return class_maternity() & class_zero_los() & class_no_birth_event()
+
+
+def is_nonelective_csection():
+    return class_maternity() & class_birth_event() & class_birth_nonelective_c_section()
+
+
+def is_elective_csection():
+    return class_maternity() & class_birth_event() & class_birth_elective_csection()
+
+
+def is_overnight_no_birth_event():
+    return class_maternity() & class_non_zero_los() & class_no_birth_event()
+
+
+def create_ip_maternity_groupings(ip_data: DataFrame) -> DataFrame:
+    """Adds "grouping" column to the IP data with the functional areas for IP daycase
+
+    Args:
+        ip_data (DataFrame): IP data
+
+    Returns:
+        DataFrame: IP data, aggregated by daycase functional areas
+    """
+    df = (
+        ip_data.withColumn(
+            "grouping",
+            F.when(is_normal_delivery(), "maternity_normal_delivery")
+            .when(is_assisted_delivery(), "maternity_assissted_delivery")
+            .when(is_maternity_assessment(), "maternity_assessment")
+            .when(is_nonelective_csection(), "maternity_nonelective_csection")
+            .when(is_elective_csection(), "maternity_elective_csection")
+            .when(is_overnight_no_birth_event(), "maternity_overnight_no_birth"),
+        )
+        .groupby("grouping", "model_run")
+        .agg(F.count("rn").alias("total"))
+    )
+    return df
+
+
+def process_ip_daycase(
+    ip_original_mapped: DataFrame, ip_model_results: DataFrame
+) -> DataFrame:
+    """Processes and aggregates the IP baseline and model results to produce functional area outputs for IP daycase,
+    aggregated by model run and grouping.
+
+    Args:
+        ip_original_mapped (DataFrame): Baseline IP data
+        ip_model_results (DataFrame): IP full model results
+
+    Returns:
+        DataFrame: IP data for each of the model runs aggregated into functional areas for daycase
+    """
+    baseline_grouped = create_ip_maternity_groupings(ip_original_mapped)
+    groupings_per_run = create_ip_maternity_groupings(
+        ip_original_mapped.drop("speldur", "classpat", "model_run").join(
+            ip_model_results, on="rn", how="left"
+        )
+    )
+    final_groupings_per_run_with_baseline = groupings_per_run.unionByName(
+        baseline_grouped
+    )
+    # Add missing groupings - we need all groupings to be present in all model runs even if value is 0
+    required_ip_groupings = [
+        "maternity_normal_delivery",
+        "maternity_assisted_delivery",
+        "maternity_assessment",
+        "maternity_nonelective_csection",
+        "maternity_elective_csection",
+        "maternity_overnight_no_birth",
+    ]
+    final_df = add_missing_groupings(
+        final_groupings_per_run_with_baseline, required_ip_groupings
+    )
+    return final_df

--- a/src/nhp/capacity/functional_areas/processing_helpers.py
+++ b/src/nhp/capacity/functional_areas/processing_helpers.py
@@ -27,8 +27,21 @@ def add_missing_groupings(
     )
     expected = model_runs.crossJoin(required_df)
     completed_required = expected.join(
-        final_groupings_per_run_with_baseline, on=["model_run", "grouping"], how="left"
-    ).withColumn("total", F.coalesce(F.col("total"), F.lit(0)))
+        final_groupings_per_run_with_baseline,
+        on=["model_run", "grouping"],
+        how="left",
+    )
+    # Fill all non-key columns with 0
+    value_columns = [
+        c
+        for c in final_groupings_per_run_with_baseline.columns
+        if c not in {"model_run", "grouping"}
+    ]
+    for col in value_columns:
+        completed_required = completed_required.withColumn(
+            col,
+            F.coalesce(F.col(col), F.lit(0)),
+        )
     non_required = final_groupings_per_run_with_baseline.filter(
         ~F.col("grouping").isin(required_groupings)
     )


### PR DESCRIPTION
Closes #34 

I use existing columns in the NHP data - `maternity_delivery_in_spell` and `group` although it strikes me that we should not use maternity_delivery_in_spell if we are taking an episode level approach?

Have run - output can be seen on Azure Storage. UUIDs:
- 8f97830f-c638-412a-bbec-4ee017ff3f8b
- 4880a765-6289-47a5-a190-c9363779c8e5